### PR TITLE
Urlencode location parameter

### DIFF
--- a/scripts/forecast.sh
+++ b/scripts/forecast.sh
@@ -7,6 +7,7 @@ source "$CURRENT_DIR/helpers.sh"
 get_forecast() {
   local format=$(get_tmux_option @forecast-format "%C+%t+%w")
   local location=$(get_tmux_option @forecast-location "") # Let wttr.in figure out the location
+  location=$(urlencode "$location")
   curl "http://wttr.in/$location?format=$format"
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -29,3 +29,17 @@ get_file_age() { # $1 - cache file
     echo 0
   fi
 }
+
+# found at https://stackoverflow.com/a/34938751
+urlencode() {
+  # urlencode <string>
+
+  local length="${#1}"
+  for (( i = 0; i < length; i++ )); do
+    local c="${1:i:1}"
+    case $c in
+      [a-zA-Z0-9.~_-:/]) printf "$c" ;;
+      *) printf '%%%x' \'"$c" ;;
+    esac
+  done
+}


### PR DESCRIPTION
Location might contain at least spaces. Simple (and dumb) function `urlencode` tries to fix it before sending request to wttr.in.

Unfortunately curl's `--data-urlencode` option only works for query parameters.